### PR TITLE
fix/修复方向按钮点击无响应

### DIFF
--- a/app/src/main/java/com/ltx/service/AutoSlideService.kt
+++ b/app/src/main/java/com/ltx/service/AutoSlideService.kt
@@ -248,6 +248,7 @@ class AutoSlideService : AccessibilityService() {
      * @param intent 启动参数
      */
     private fun updateConfigFromIntent(intent: Intent) {
+        intent.getStringExtra("direction")?.let { setDirection(it) }
         speed = intent.getIntExtra("speed", DEFAULT_SPEED)
         pauseMode = intent.getIntExtra("pauseMode", PAUSE_MODE_NONE)
         pauseTime = intent.getIntExtra("pauseTime", DEFAULT_PAUSE_SECONDS).coerceAtLeast(1)

--- a/app/src/main/java/com/ltx/service/FloatingWindowService.kt
+++ b/app/src/main/java/com/ltx/service/FloatingWindowService.kt
@@ -233,9 +233,8 @@ class FloatingWindowService : Service() {
      */
     private fun bindDirectionButton(viewId: Int, direction: String) {
         rootView.findViewById<View>(viewId).setOnClickListener {
-            val service = AutoSlideService.getInstance() ?: return@setOnClickListener
-            service.setDirection(direction)
-            startSlide()
+            AutoSlideService.getInstance()?.setDirection(direction)
+            startSlide(direction)
         }
     }
 
@@ -290,12 +289,14 @@ class FloatingWindowService : Service() {
     /**
      * 启动自动滑动服务
      *
+     * @param direction 滑动方向
      */
-    private fun startSlide() {
+    private fun startSlide(direction: String = DIRECTION_LEFT) {
         minimize()
         // 从本地配置文件读取当前设置
         val prefs: SharedPreferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         val intent = Intent(this, AutoSlideService::class.java).apply {
+            putExtra("direction", direction)
             putExtra(KEY_SPEED, prefs.getInt(KEY_SPEED, DEFAULT_SPEED))
             var pauseMode = prefs.getInt(KEY_PAUSE_MODE, -1)
             if (pauseMode == -1) {


### PR DESCRIPTION

在部分设备（如一加15 ColorOS 16）上，无障碍服务可能未及时连接，getInstance() 返回 null 导致方向按钮点击无响应

修复: 通过 Intent 传递滑动方向，使 startSlide() 不再依赖服务实例是否就绪，并在 AutoSlideService.updateConfigFromIntent() 中读取方向参数